### PR TITLE
Admin site: fix grant links from GP page

### DIFF
--- a/sjfnw/fund/admin.py
+++ b/sjfnw/fund/admin.py
@@ -155,12 +155,13 @@ class ProjectAppInline(admin.TabularInline):
   app_link.allow_tags = True
 
   def grant_link(self, obj):
-    if obj and hasattr(obj, 'projectapp_id'):
-      return ('<a href="/admin/grants/givingprojectgrant/{}/">View grant</a>'
-              .format(obj.projectapp_id))
-    if obj and hasattr(obj, 'screening_status') and obj.screening_status > 80:
-      return ('<a href="/admin/grants/givingprojectgrant/add/?projectapp={}">Add grant</a>'
-              .format(obj.pk))
+    if obj:
+      if hasattr(obj, 'givingprojectgrant'):
+        return ('<a href="/admin/grants/givingprojectgrant/{}/">View grant</a>'
+                .format(obj.givingprojectgrant.pk))
+      if hasattr(obj, 'screening_status') and obj.screening_status > 80:
+        return ('<a href="/admin/grants/givingprojectgrant/add/?projectapp={}">Add grant</a>'
+                .format(obj.pk))
     return ''
   grant_link.allow_tags = True
 


### PR DESCRIPTION
I was checking the wrong field - `projectapp_id` when `obj` itself is a projectapp. I meant to be checking for whether a grant is attached or not. Updated to check for `givingprojectgrant` (a reverse one-to-one can be accessed directly like that, but will throw an error if not found, thus the `hasattr`)

Nested vs. separate if statements wouldn't make any difference for results, but it makes sense to just do if `if obj` check once instead of twice, so I made that change too.

Fixes #759 

@tarhata 