### PR TITLE
removed extra break in gift email notification

### DIFF
--- a/sjfnw/templates/fund/emails/gift_received.html
+++ b/sjfnw/templates/fund/emails/gift_received.html
@@ -1,4 +1,4 @@
-﻿<p>Social Justice Fund has received donations and/or pledges from one or more of your donors!</p><br>
+﻿<p>Social Justice Fund has received donations and/or pledges from one or more of your donors!</p>
 <p>{{gift_str}}</p>
 <p>Visit your <a href="{{login_url}}">fundraising page</a> for more information.</p>
 <p>-Project Central</p>


### PR DESCRIPTION
Noticed there was an un-necessary `<br>` in the gift notification email. Glad to see that it's working fine though! :grinning: 

![image](https://cloud.githubusercontent.com/assets/8212941/7710068/2dcb75fa-fe16-11e4-93ad-81e676fd1d9e.png)
