### PR TITLE
Add instructions for running mysql

### DIFF
--- a/docs/getting-started/local-server.md
+++ b/docs/getting-started/local-server.md
@@ -6,6 +6,8 @@ From inside the root of the repo do
 
 _If you get something like 'command not found', make sure GAE is in your path. Use `echo $PATH` to confirm. See [setup](installation-and-setup.md#update-paths)._
 
+_If you see a mySQL connection error, make sure that mySQL is running in another terminal window: `$ mysqld`_
+
 ---
 
 ### Create accounts (first time only)


### PR DESCRIPTION
Kept running into `OperationalError: (2003, "Can't connect to MySQL server on 'localhost' (61)")` and other variations on that theme when trying to start a local development server.

At work I always have mysql already running, so I keep forgetting to start mySQL! This adds to the docs to make sure that others don't have that problem.