### PR TITLE
Remove non ascii chars

### DIFF
--- a/sjfnw/grants/models.py
+++ b/sjfnw/grants/models.py
@@ -209,7 +209,7 @@ class WordLimitValidator(BaseValidator):
     return count_a > count_b
 
   def clean(self, val):
-    return len(utils.strip_punctuation(val).split())
+    return len(utils.strip_punctuation_and_non_ascii(val).split())
 
 
 def validate_file_extension(value):

--- a/sjfnw/grants/models.py
+++ b/sjfnw/grants/models.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-import json, logging, string
+import json, logging
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -8,7 +8,7 @@ from django.db import models
 from django.utils import timezone
 
 from sjfnw.fund.models import GivingProject
-from sjfnw.grants import constants as gc
+from sjfnw.grants import constants as gc, utils
 
 logger = logging.getLogger('sjfnw')
 
@@ -209,7 +209,7 @@ class WordLimitValidator(BaseValidator):
     return count_a > count_b
 
   def clean(self, val):
-    return len(unicode(val).translate({ord(c): None for c in string.punctuation}).split())
+    return len(utils.strip_punctuation(val).split())
 
 
 def validate_file_extension(value):

--- a/sjfnw/grants/tests/test_utils.py
+++ b/sjfnw/grants/tests/test_utils.py
@@ -4,18 +4,18 @@ from django.test import TestCase
 
 from sjfnw.grants import utils
 
-class StripPuncuation(TestCase):
+class StripPunctuation(TestCase):
 
   def test_str(self):
-    result = utils.strip_punctuation('Hello, here\'s a list : - one! * two; + three')
+    result = utils.strip_punctuation_and_non_ascii('Hello, here\'s a list : - one! * two; + three')
     self.assertEqual(result, 'Hello heres a list   one  two  three')
 
-    result = utils.strip_punctuation('Watch=these, / ^other $chars@get (removed) `too\r &&')
+    result = utils.strip_punctuation_and_non_ascii('Watch=these, / ^other $chars@get (removed) `too\r &&')
     self.assertEqual(result, 'Watchthese  other charsget removed too\r ')
 
   def test_unicode(self):
-    result = utils.strip_punctuation(u'Hello‚ here’s å lˆst – □ oñe▶ ● two; +◇ thrée')
-    self.assertEqual(result, u'Hello heres å lst   oñe  two  thrée')
+    result = utils.strip_punctuation_and_non_ascii(u'Hello‚ here’s å lˆst – □ oñe▶ ● two; +◇ thrée')
+    self.assertEqual(result, u'Hello heres  lst   oe  two  thre')
 
-    result = utils.strip_punctuation(u'Watch‐these, • ‘other ▹chars‒get “removed” `too\r ■')
+    result = utils.strip_punctuation_and_non_ascii(u'Watch‐these, • ‘other ▹chars‒get “removed” `too\r ■')
     self.assertEqual(result, u'Watchthese  other charsget removed too\r ')

--- a/sjfnw/grants/tests/test_utils.py
+++ b/sjfnw/grants/tests/test_utils.py
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+from django.test import TestCase
+
+from sjfnw.grants import utils
+
+class StripPuncuation(TestCase):
+
+  def test_str(self):
+    result = utils.strip_punctuation('Hello, here\'s a list : - one! * two; + three')
+    self.assertEqual(result, 'Hello heres a list   one  two  three')
+
+    result = utils.strip_punctuation('Watch=these, / ^other $chars@get (removed) `too\r &&')
+    self.assertEqual(result, 'Watchthese  other charsget removed too\r ')
+
+  def test_unicode(self):
+    result = utils.strip_punctuation(u'Hello‚ here’s å lˆst – □ oñe▶ ● two; +◇ thrée')
+    self.assertEqual(result, u'Hello heres å lst   oñe  two  thrée')
+
+    result = utils.strip_punctuation(u'Watch‐these, • ‘other ▹chars‒get “removed” `too\r ■')
+    self.assertEqual(result, u'Watchthese  other charsget removed too\r ')

--- a/sjfnw/grants/tests/test_validators.py
+++ b/sjfnw/grants/tests/test_validators.py
@@ -31,10 +31,10 @@ EXAMPLES = [
   {
     'text': (u'This gránt will provide funding for two years. While we know it'
       u' can be difficult to predict your work beyond a year, please give us an'
-      u' idea of what the second year might look like.\t - What overall goals and'
-      u' strategies do you ø∆ forecast in the second year?\t* How will the second year'
-      u' of this grant build on your work in the first year?\r'),
-    'expected_count': 64,
+      u' idea of what the second year might look like.\t - • What overall goals and'
+      u' strategies ø∆ do you – forecast in the second year?\t* How will the second year'
+      u' of this grant éñô build on your work in the first year?\r'),
+    'expected_count': 65,
     'simple': False
   }
 ]

--- a/sjfnw/grants/tests/test_validators.py
+++ b/sjfnw/grants/tests/test_validators.py
@@ -32,9 +32,9 @@ EXAMPLES = [
     'text': (u'This gránt will provide funding for two years. While we know it'
       u' can be difficult to predict your work beyond a year, please give us an'
       u' idea of what the second year might look like.\t - • What overall goals and'
-      u' strategies ø∆cat do you – forecast in the second year?\t* How will the second year'
+      u' strategies ø∆ do you – forecast in the second year?\t* How will the second year'
       u' of this grant éñôcat build on your work in the first year?\r'),
-    'expected_count': 65,
+    'expected_count': 64,
     'simple': False
   }
 ]

--- a/sjfnw/grants/tests/test_validators.py
+++ b/sjfnw/grants/tests/test_validators.py
@@ -32,8 +32,8 @@ EXAMPLES = [
     'text': (u'This gránt will provide funding for two years. While we know it'
       u' can be difficult to predict your work beyond a year, please give us an'
       u' idea of what the second year might look like.\t - • What overall goals and'
-      u' strategies ø∆ do you – forecast in the second year?\t* How will the second year'
-      u' of this grant éñô build on your work in the first year?\r'),
+      u' strategies ø∆cat do you – forecast in the second year?\t* How will the second year'
+      u' of this grant éñôcat build on your work in the first year?\r'),
     'expected_count': 65,
     'simple': False
   }

--- a/sjfnw/grants/utils.py
+++ b/sjfnw/grants/utils.py
@@ -1,4 +1,6 @@
-import logging, re
+# encoding: utf-8
+
+import logging, re, string
 
 from django.conf import settings
 from django.http import HttpResponse, Http404
@@ -7,6 +9,13 @@ from django.utils import timezone
 from google.appengine.ext import blobstore
 
 logger = logging.getLogger('sjfnw')
+
+# checking subset of unicode punctuation for speed - chars most likely to be in user input
+punctuation = string.punctuation + u'‐‑‒–—―‘’‚‛“”‟ˆ•∘∙■□▢▪▫▲△▴▵▶▷▸▹►▻▼▽▾▿◀◁◂◃◄◅◆◇○●'
+
+def strip_punctuation(input_str):
+  input_str = unicode(input_str) # input may or may not be unicode already
+  return ''.join([c for c in input_str if c not in punctuation])
 
 def local_date_str(timestamp):
   """ Convert UTC timestamp to local date string in mm/dd/yyyy format """

--- a/sjfnw/grants/utils.py
+++ b/sjfnw/grants/utils.py
@@ -10,12 +10,11 @@ from google.appengine.ext import blobstore
 
 logger = logging.getLogger('sjfnw')
 
-# checking subset of unicode punctuation for speed - chars most likely to be in user input
-punctuation = string.punctuation + u'‐‑‒–—―‘’‚‛“”‟ˆ•∘∙■□▢▪▫▲△▴▵▶▷▸▹►▻▼▽▾▿◀◁◂◃◄◅◆◇○●'
+# removing all non-ascii characters, which could be problem for words of only non-ascii characters, but javascript will be consistent, so okay for matching word counts.
 
-def strip_punctuation(input_str):
+def strip_punctuation_and_non_ascii(input_str):
   input_str = unicode(input_str) # input may or may not be unicode already
-  return ''.join([c for c in input_str if c not in punctuation])
+  return ''.join([c for c in input_str if c not in string.punctuation and ord(c)<128])
 
 def local_date_str(timestamp):
   """ Convert UTC timestamp to local date string in mm/dd/yyyy format """

--- a/sjfnw/static/js/forms.js
+++ b/sjfnw/static/js/forms.js
@@ -78,8 +78,10 @@ function updateWordCount(event) {
   var word_count = 0;
   if (area.value && area.value.trim()) {
     // match the chars in python's string.punctuation
+    // remove non-ascii characters
     word_count = area.value
       .replace(/[!"#$%&'()*+,-.\/:;<=>?@\[\\\]\^_`{|}~]/g, '')
+      .replace(/[^\x00-\x7F]/g, "")
       .split(/[ \r\n]+/)
       .length;
   }


### PR DESCRIPTION
This isn't exactly what is documented in https://github.com/aisapatino/sjfnw/issues/822 but should be sufficient. All non-ascii characters and punctuation characters from python's string.punctuation are removed in both python and javascript, so the word counts should match, and be generally correct (words consisting of all non-ascii characters won't be counted, but that shouldn't be big problem.)