### PR TITLE
update installation docs for mysql with homebrew

### DIFF
--- a/docs/getting-started/installation-and-setup.md
+++ b/docs/getting-started/installation-and-setup.md
@@ -21,7 +21,7 @@ May be installed already, check with `git --version`. Install/update using packa
 Install mysql and a python-mysql adapter.
 
 Linux: `apt-get install mysql-server python-mysqldb`  
-OSX: `brew install mysql`, `pip install mysql-python`
+OSX: `brew install mysql@5.6`, `pip install mysql-python`
 
 If prompted for a password, enter the password from [`sjfnw/settings.py`](https://github.com/aisapatino/sjfnw/blob/master/sjfnw/settings.py#L43).
 


### PR DESCRIPTION
The default version of mysql installed by homebrew is currently 8, which doesn't match the expected
version in `verify-install`